### PR TITLE
Add SimpleOrigin to the StarLasu Ecore metamodel

### DIFF
--- a/src/interop/starlasu-v2-metamodel.ts
+++ b/src/interop/starlasu-v2-metamodel.ts
@@ -68,6 +68,21 @@ THE_ORIGIN_ECLASS.get("eStructuralFeatures").add(Ecore.EReference.create({
     eType: THE_POSITION_ECLASS,
     containment: true
 }));
+export const THE_SIMPLE_ORIGIN_ECLASS = Ecore.EClass.create({
+    name: "SimpleOrigin"
+});
+THE_SIMPLE_ORIGIN_ECLASS.get("eSuperTypes").add(THE_ORIGIN_ECLASS);
+THE_SIMPLE_ORIGIN_ECLASS.get("eStructuralFeatures").add(Ecore.EAttribute.create({
+    name: "sourceText",
+    eType: Ecore.EString,
+    lowerBound: 0
+}));
+THE_SIMPLE_ORIGIN_ECLASS.get("eStructuralFeatures").add(Ecore.EReference.create({
+    name: "position",
+    eType: THE_POSITION_ECLASS,
+    lowerBound: 0,
+    containment: true
+}));
 THE_NODE_ECLASS.get("eStructuralFeatures").add(Ecore.EReference.create({
     name: "destination",
     eType: THE_DESTINATION_INTERFACE,
@@ -287,6 +302,7 @@ THE_AST_EPACKAGE.get('eClassifiers').add(THE_ORIGIN_ECLASS);
 THE_AST_EPACKAGE.get('eClassifiers').add(THE_DESTINATION_INTERFACE);
 THE_AST_EPACKAGE.get('eClassifiers').add(THE_NODE_ECLASS);
 THE_AST_EPACKAGE.get('eClassifiers').add(THE_NODE_ORIGIN_ECLASS);
+THE_AST_EPACKAGE.get('eClassifiers').add(THE_SIMPLE_ORIGIN_ECLASS);
 THE_AST_EPACKAGE.get('eClassifiers').add(THE_POINT_ECLASS);
 THE_AST_EPACKAGE.get('eClassifiers').add(THE_POSITION_ECLASS);
 THE_AST_EPACKAGE.get('eClassifiers').add(THE_POSSIBLY_NAMED_INTERFACE);

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -83,6 +83,20 @@ export abstract class Origin {
 
 }
 
+export class SimpleOrigin extends Origin {
+    constructor(public myPosition?: Position, public mySourceText?: string) {
+        super();
+    }
+
+    get position(): Position | undefined {
+        return this.myPosition
+    }
+
+    get sourceText(): string | undefined {
+        return this.mySourceText
+    }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Destination {}
 

--- a/tests/data/playground/java/trace-with-simple-origins.json
+++ b/tests/data/playground/java/trace-with-simple-origins.json
@@ -1,0 +1,43 @@
+{
+  "eClass" : "https://strumenta.com/starlasu/transpilation/v2#//WorkspaceTranspilationTrace",
+  "originalFiles" : [ {
+    "path" : "CUS300.rpgle",
+    "code" : "     F**********************************************************************\n     F*                                                                    *\n     F* PROGRAM ID  : CUS200                                               *\n     F* PROGRAM NAME: SAMPLE PROGRAM                                       *\n     F*                                                                    *\n     F**********************************************************************\n     D DSP             S             50    INZ('CUSTOMER')\n     D TOTAL           S              9P 2 INZ(0)\n     D NUM             S              9P 2 INZ(1)\n     D CNT             S              9P 2 INZ(0)\n     FCUSTOMER  UF   E           K Disk\n     FORDERS    IF   E           K Disk\n     FORDSUM    IF   E           K Disk\n     C     *INZSR        BEGSR\n     C                   EVAL      DSP='CUSTOMER REPORT'\n     C                   DSPLY     DSP\n     C                   ENDSR\n      /free\n            CNT = 0;\n            TOTAL = 0;\n            EXSR $clrsum;\n            DSPLY '------  Forward  ------';\n            Setll *Loval CUSTOMER;\n            Dou NOT %EOF(CUSTOMER);\n                Read CUSTOMER;\n                If NOT %EOF(CUSTOMER);\n                   EXSR $calctotal;\n                   EXSR $DSPCUS;\n                   If TOTAL > 0;\n                       OSCUID = CUID;\n                       TOTAL *=  (TOTAL / CNT +1) * 0.1;\n                       OSTOT = TOTAL;\n                       OSCUNM = CUSTNM;\n                       Write  ORDSUM;\n                    EndIf;\n                EndIf;\n            EndDO;\n            DSPLY '------  Reverse  ------';\n            Setll *Hival ORDSUM;\n            Dou NOT %EOF(ORDSUM);\n                Readp ORDSUM;\n                If NOT %EOF(ORDSUM);\n                    DSPLY 'CUSTOMER: ' + OSCUNM + ' $' + OSTOT;\n\n                EndIf;\n            EndDO;\n\n            Begsr  $calctotal;\n                CNT = 0;\n                TOTAL = 0;\n                Setll *Loval ORDERS;\n                Dou NOT %EOF(ORDERS);\n                    Read ORDERS;\n                    If NOT %EOF(ORDERS);\n                        If CUID = ORCUID;\n                            TOTAL += ORTOT;\n                            CNT += 1;\n                        EndIf;\n                    EndIf;\n                EndDo;\n            EndSr;\n\n            Begsr  $dspcus;\n                If TOTAL > 0;\n                    eval DSP='CUSTOMER: ' + CUSTNM + ' $' + TOTAL;\n                    DSPLY     DSP;\n                EndIf;\n            EndSr;\n\n            Begsr  $clrsum;\n                CNT = 0;\n                DSPLY '------  Delete  ------';\n                Setll *Loval ORDSUM;\n                Dou NOT %EOF(ORDSUM);\n                    Read ORDSUM;\n                    If NOT %EOF(ORDSUM);\n                        delete ORDSUM;\n                        CNT+=1;\n                    EndIf;\n                EndDO;\n                DSPLY 'DELETED: ' + CNT +  ' RECORDS';\n            EndSr;",
+    "result" : {
+      "root" : {
+        "eClass" : "https://strumenta.com/rpg/model#//CompilationUnit",
+        "position" : {
+          "start" : {
+            "line" : 1
+          },
+          "end" : {
+            "line" : 82,
+            "column" : 18
+          }
+        },
+        "comments" : [],
+        "dataDefinitions" : [],
+        "externalDefinitions" : [],
+        "fileDescriptions" : [],
+        "mainStatements" : [],
+        "subroutines" : [],
+        "origin" : {
+          "eClass" : "https://strumenta.com/starlasu/v2#//SimpleOrigin",
+          "sourceText" : "Footext",
+          "position" : {
+            "start" : {
+              "line" : 1,
+              "column" : 20
+            },
+            "end" : {
+              "line" : 1,
+              "column" : 34
+            }
+          }
+        }
+      }
+    }
+  } ],
+  "generatedFiles" : [
+   ]
+}

--- a/tests/interop/workspace-transpilation-trace.test.ts
+++ b/tests/interop/workspace-transpilation-trace.test.ts
@@ -122,4 +122,30 @@ describe('Workspace Transpilation traces', function() {
                     expect(destinationNodes.length).to.equal(1);
                     expect(destinationNodes[0].file?.path).to.equal("Cus300.java");
             });
+    it("Can load workspace transpilation trace produced by Kolasu with SimpleOrigin instances",
+        function () {
+            this.timeout(0);
+            Ecore.EPackage.Registry.register(THE_AST_EPACKAGE);
+            Ecore.EPackage.Registry.register(TRANSPILATION_EPACKAGE);
+            const loader = new TranspilationTraceLoader({
+                name: "rpg2py",
+                uri: "file://tests/data/playground/rpg/rpg2py-metamodels.json",
+                metamodel: JSON.parse(fs.readFileSync("tests/data/playground/java/rpg2java-metamodels.json").toString())
+            });
+            const example = fs.readFileSync("tests/data/playground/java/trace-with-simple-origins.json").toString();
+            const trace = loader.loadWorkspaceTranspilationTrace(example);
+
+            expect(trace.originalFiles.length).to.eql(1);
+            expect(trace.generatedFiles.length).to.eql(0);
+            expect(trace.transpilationIssues.length).to.eql(0);
+
+            const cus300File = trace.originalFiles[0];
+            expect(cus300File.path).to.eql("CUS300.rpgle")
+            expect(cus300File.issues.length).to.eql(0)
+            expect(cus300File.node.getType()).to.eql("com.strumenta.rpgparser.model.CompilationUnit")
+            expect(cus300File.node.getSimpleType()).to.eql("CompilationUnit")
+            // The origin is ignored. The position loaded is the explicit position
+            // The sourceText is not accessible anywhere, as it is irrelevant for the TranspilationTrace
+            expect(cus300File.node.getPosition()).to.eql(new Position(new Point(1, 0), new Point(82, 18)))
+        });
 });


### PR DESCRIPTION
SimpleOrigin as been added to the StarLasu metamodel in Kolasu but not in Tylasu.

For the Kolasu version see [this](https://github.com/Strumenta/kolasu/blob/299706d32af4987e3788c62bf43c9eebe3e76d3e/emf/src/main/kotlin/com/strumenta/kolasu/emf/KolasuMetamodel.kt#L81)

For example, we have in a trace.json file this snippet:

```
"origin" : {
            "eClass" : "https://strumenta.com/starlasu/v2#//SimpleOrigin",
            "sourceText" : "DECEDIT('0,')",
            "position" : {
              "start" : {
                "line" : 1,
                "column" : 6
              },
              "end" : {
                "line" : 1,
                "column" : 19
              }
            }
          },
```          