### PR TITLE
Differentiating between several parser and lexer issues

### DIFF
--- a/tests/parsing.test.ts
+++ b/tests/parsing.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 
-import {Issue, Node} from "../src";
+import {Issue, IssueSeverity, IssueType, Node, Point, Position} from "../src";
 import {SimpleLangLexer} from "./parser/SimpleLangLexer";
 import {CharStream, Lexer, TokenStream} from "antlr4ng";
 import {CompilationUnitContext, SimpleLangParser} from "./parser/SimpleLangParser";
@@ -36,4 +36,193 @@ describe('Parsing', function() {
             expect(result.root!.parseTree).to.equal(result.firstStage!.root);
             expect(result.code).to.equal(code);
         });
+    it("produce correct issues for: display 1 +",
+        function () {
+            const code = "display 1 +";
+            const parser = new SLParser(new ANTLRTokenFactory());
+            const result = parser.parse(code);
+            expect(result.issues).to.eql([new Issue(
+                IssueType.SYNTACTIC,
+                "mismatched input '<EOF>' expecting {INT_LIT, DEC_LIT, STRING_LIT, BOOLEAN_LIT}",
+                IssueSeverity.ERROR,
+                new Position(new Point(1, 11), new Point(1, 11)),
+                undefined,
+                "parser.mismatchedinput",
+                [
+                    {
+                        name: "mismatched",
+                        value: "<EOF>"
+                    },
+                    {
+                    name: "expected",
+                    value: "INT_LIT"
+                    },
+                    {
+                        name: "expected",
+                        value: "DEC_LIT"
+                    },
+                    {
+                        name: "expected",
+                        value: "STRING_LIT"
+                    },
+                    {
+                        name: "expected",
+                        value: "BOOLEAN_LIT"
+                    }
+                ]
+            )])
+        });
+    it("produce correct issues for: display 1 ++",
+        function () {
+            const code = "display 1 ++";
+            const parser = new SLParser(new ANTLRTokenFactory());
+            const result = parser.parse(code);
+            expect(result.issues).to.eql([
+                new Issue(
+                    IssueType.SYNTACTIC,
+                    "mismatched input '+' expecting {INT_LIT, DEC_LIT, STRING_LIT, BOOLEAN_LIT}",
+                    IssueSeverity.ERROR,
+                    new Position(new Point(1, 11), new Point(1, 11)),
+                    undefined,
+                    "parser.mismatchedinput",
+                    [
+                        {
+                            name: "mismatched",
+                            value: "+"
+                        },
+                        {
+                            name: "expected",
+                            value: "INT_LIT"
+                        },
+                        {
+                            name: "expected",
+                            value: "DEC_LIT"
+                        },
+                        {
+                            name: "expected",
+                            value: "STRING_LIT"
+                        },
+                        {
+                            name: "expected",
+                            value: "BOOLEAN_LIT"
+                        }
+                    ]
+                ),
+                new Issue(
+                IssueType.SYNTACTIC,
+                "mismatched input '<EOF>' expecting {INT_LIT, DEC_LIT, STRING_LIT, BOOLEAN_LIT}",
+                IssueSeverity.ERROR,
+                new Position(new Point(1, 12), new Point(1, 12)),
+                undefined,
+                "parser.mismatchedinput",
+                [
+                    {
+                        name: "mismatched",
+                        value: "<EOF>"
+                    },
+                    {
+                        name: "expected",
+                        value: "INT_LIT"
+                    },
+                    {
+                        name: "expected",
+                        value: "DEC_LIT"
+                    },
+                    {
+                        name: "expected",
+                        value: "STRING_LIT"
+                    },
+                    {
+                        name: "expected",
+                        value: "BOOLEAN_LIT"
+                    }
+                ]
+            )])
+        });
+    it("produce correct issues for: display",
+        function () {
+            const code = "display";
+            const parser = new SLParser(new ANTLRTokenFactory());
+            const result = parser.parse(code);
+            expect(result.issues).to.eql([
+                new Issue(
+                    IssueType.SYNTACTIC,
+                    "mismatched input '<EOF>' expecting {INT_LIT, DEC_LIT, STRING_LIT, BOOLEAN_LIT}",
+                    IssueSeverity.ERROR,
+                    new Position(new Point(1, 7), new Point(1, 7)),
+                    undefined,
+                    "parser.mismatchedinput",
+                    [
+                        {
+                            name: "mismatched",
+                            value: "<EOF>"
+                        },
+                        {
+                            name: "expected",
+                            value: "INT_LIT"
+                        },
+                        {
+                            name: "expected",
+                            value: "DEC_LIT"
+                        },
+                        {
+                            name: "expected",
+                            value: "STRING_LIT"
+                        },
+                        {
+                            name: "expected",
+                            value: "BOOLEAN_LIT"
+                        }
+                    ]
+                )])
+        });
+    it("produce correct issues for: ###",
+        function () {
+            const code = "###";
+            const parser = new SLParser(new ANTLRTokenFactory());
+            const result = parser.parse(code);
+            expect(result.issues).to.eql([
+                new Issue(
+                    IssueType.LEXICAL,
+                    "token recognition error at: '#'",
+                    IssueSeverity.ERROR,
+                    new Position(new Point(1, 0), new Point(1, 0)),
+                    undefined,
+                    "lexer.tokenrecognitionerror",
+                    [
+                        {
+                            name: "token",
+                            value: "#"
+                        }
+                    ]
+                ),
+                new Issue(
+                    IssueType.LEXICAL,
+                    "token recognition error at: '#'",
+                    IssueSeverity.ERROR,
+                    new Position(new Point(1, 1), new Point(1, 1)),
+                    undefined,
+                    "lexer.tokenrecognitionerror",
+                    [
+                        {
+                            name: "token",
+                            value: "#"
+                        }
+                    ]
+                ),
+                new Issue(
+                    IssueType.LEXICAL,
+                    "token recognition error at: '#'",
+                    IssueSeverity.ERROR,
+                    new Position(new Point(1, 2), new Point(1, 2)),
+                    undefined,
+                    "lexer.tokenrecognitionerror",
+                    [
+                        {
+                            name: "token",
+                            value: "#"
+                        }
+                    ]
+                )])
+        })
 });


### PR DESCRIPTION
I think that, in order to facilitate the translation of error messages, we need to produce different codes for different messages. We also need to provide all the arguments needed to recreate the messages in another language.

Unfortunately, that means looking at the actual strings being generated unless we replace the DefaultErrorStrategy with a different one (if you prefer that I go that route, let me know, and I will update the PR).

Note also that in some cases, we produce more than one argument with the same name, implicitly providing an array. This is the case, for example, for cases where we need to report multiple tokens that could be used at a certain point. We could report all of them in a single string with commas, but perhaps in certain languages, they do not use commas

Fix #71 