### PR TITLE
Improve parsing `Issue`s reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project from version 1.2.0 upwards are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+- `Position`'s method `isEmpty` is deprecated in favour of `isFlat` to ensure consistency across the [StarLasu](https://github.com/Strumenta/StarLasu) libraries collection.
+- `Issue`'s messages are capitalized.
+- Parsing `Issue`s' position uses the token's length.
+
 ## [1.6.29] – 2024-07-09
 
 ### Fixed

--- a/src/model/position.ts
+++ b/src/model/position.ts
@@ -131,10 +131,18 @@ export class Position {
 
     /**
      * If start and end are the same,
-     * then this Position is considered empty.
+     * then this Position is considered flat.
+     */
+    isFlat(): boolean {
+        return this.start.equals(this.end);
+    }
+
+    /**
+     * @deprecated
+     * Use `this.isFlat()` instead.
      */
     isEmpty(): boolean {
-        return this.start.equals(this.end)
+        return this.isFlat();
     }
 
     /**

--- a/src/utils/capitalize.ts
+++ b/src/utils/capitalize.ts
@@ -1,0 +1,6 @@
+/**
+* Capitalize the first letter of a string
+*/
+export function capitalize(str: string) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,5 +1,6 @@
 import {Node} from "./model/model";
 import {Position} from "./model/position";
+import { capitalize } from "./utils/capitalize";
 
 export enum IssueType { LEXICAL, SYNTACTIC, SEMANTIC}
 
@@ -21,6 +22,8 @@ export class Issue {
         public readonly code?: string,
         public readonly args: IssueArg[] = []
         ) {
+        this.message = capitalize(message);
+
         if (!position) {
             this.position = node?.position;
         }

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -30,4 +30,10 @@ describe('Issues', function() {
                 SOURCE_NODE_NOT_MAPPED,  [{ name: "nodeType", value: "SomeNode" }]);
             expect(i18next.t(issue.code!, { type: issue.args[0].value })).to.equal("Source node not mapped: SomeNode");
         });
+
+    it("has capitalized messages",
+        function () {
+            let issue = Issue.syntactic("unexpected token: foo", IssueSeverity.ERROR, undefined, undefined, SYNTAX_ERROR);
+            expect(issue.message).to.equal("Unexpected token: foo");
+        });
 });

--- a/tests/parsing.test.ts
+++ b/tests/parsing.test.ts
@@ -82,7 +82,7 @@ describe('Parsing', function() {
                     IssueType.SYNTACTIC,
                     "mismatched input '+' expecting {INT_LIT, DEC_LIT, STRING_LIT, BOOLEAN_LIT}",
                     IssueSeverity.ERROR,
-                    new Position(new Point(1, 11), new Point(1, 11)),
+                    new Position(new Point(1, 11), new Point(1, 12)),
                     undefined,
                     "parser.mismatchedinput",
                     [
@@ -224,5 +224,23 @@ describe('Parsing', function() {
                         }
                     ]
                 )])
+        })
+    it("produces issues with non-flat positions",
+        function() {
+            const code =
+                "set set a = 10\n" +
+                "|display c\n";
+            const parser = new SLParser(new ANTLRTokenFactory());
+            const result = parser.parse(code);
+
+            expect(result.issues.length).to.not.eq(0)
+
+            const extraneousInput = result.issues.find(issue => issue.message.startsWith("Extraneous input 'set'"))
+            expect(!(extraneousInput?.position?.isFlat()))
+            expect(extraneousInput?.position).to.eql(new Position(new Point(1, 4), new Point(1, 7)))
+
+            const mismatchedInput = result.issues.find(issue => issue.message.startsWith("Mismatched input 'c'"))
+            expect(!(mismatchedInput?.position?.isFlat()))
+            expect(mismatchedInput?.position).to.eql(new Position(new Point(2, 9), new Point(2, 10)))
         })
 });

--- a/tests/transformation/transformation.test.ts
+++ b/tests/transformation/transformation.test.ts
@@ -101,9 +101,9 @@ describe("AST Transformers", function () {
        transformer.addIssue("warning", IssueSeverity.WARNING);
        transformer.addIssue("info", IssueSeverity.INFO, pos(1, 0, 1, 2));
 
-       expect(transformer.issues[0].message).to.be.equal("error");
-       expect(transformer.issues[1].message).to.be.equal("warning");
-       expect(transformer.issues[2].message).to.be.equal("info");
+       expect(transformer.issues[0].message).to.be.equal("Error");
+       expect(transformer.issues[1].message).to.be.equal("Warning");
+       expect(transformer.issues[2].message).to.be.equal("Info");
    });
    it("transform function does not accept collections as source", function () {
        const transformer = new ASTTransformer();


### PR DESCRIPTION
Resolve #59
Inspired by [Strumenta/kolasu#292](https://github.com/Strumenta/kolasu/pull/292).

- `Issue`'s messages are now capitalized to improve readability.
- `Position`'s `isEmpty` method has been safely renamed to `isFlat` to match the [convention used in kolasu](https://github.com/Strumenta/kolasu/blob/0676131e403718d2d99c792dc0a81a87bd48a34f/ast/src/commonMain/kotlin/com/strumenta/kolasu/model/Point.kt#L136). This ensures consistency across the StarLasu collection. The `isEmpty` method has now been deprecated and is to be removed in the future.
- Parsing `Issue`s report the correct `Position` by taking into consideration the length of the token, to improve UX.

---
The above message has been included in the commit's description.
Test coverage has been extended to the new features.
The changelog has been updated to reflect the changes, with the version `Unreleased` to facilitate library moderation.