### PR TITLE
Added `Node.transformChildren`, `Node.replaceWith`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project from version 1.2.0 upwards are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+- `Node.transformChildren` to run a function on all the children of a Node
+- `Node.replaceWith` to replace a Node with another
+
 ## [1.6.29] – 2024-07-09
 
 ### Fixed

--- a/tests/nodes/nodes.test.ts
+++ b/tests/nodes/nodes.test.ts
@@ -1,0 +1,64 @@
+import { expect } from "chai";
+import { Box, SomeNode, SomeNodeInPackage } from "../nodes";
+
+describe('Node.transformChildren', () => {
+    let childNode1: SomeNode;
+    let childNode2: SomeNode;
+    let boxNode: Box;
+
+    beforeEach(() => {
+        childNode1 = new SomeNode("Child1");
+        childNode2 = new SomeNode("Child2");
+
+        boxNode = new Box("BoxNode", [childNode1, childNode2]);
+    })
+
+    it('should apply in-place transformation to each child node', () => {
+        const inPlaceTransformation = (node: SomeNode): SomeNode => {
+            node.a = node.a?.toUpperCase();
+            return node;
+        };
+
+        boxNode.transformChildren(inPlaceTransformation);
+
+        expect(boxNode.contents[0]["a"]).to.eq("CHILD1");
+        expect(boxNode.contents[0]).to.eq(childNode1);
+        expect(boxNode.contents[1]["a"]).to.eq("CHILD2");
+        expect(boxNode.contents[1]).to.eq(childNode2);
+    });
+
+    it('should replace children nodes when used with pure-functions', () => {
+        const replaceTransformation = (node: SomeNode): SomeNode => {
+            return new SomeNode(node.a?.toUpperCase())
+        };
+
+        boxNode.transformChildren(replaceTransformation);
+
+        expect(boxNode.contents[0]["a"]).to.eq("CHILD1");
+        expect(boxNode.contents[0]).to.not.eq(childNode1);
+        expect(boxNode.contents[1]["a"]).to.eq("CHILD2");
+        expect(boxNode.contents[1]).to.not.eq(childNode2);
+    });
+});
+
+describe('Node.replaceWith', () => {
+    it('should replace a child node with another node', () => {
+        const childNode1 = new SomeNode("Child1");
+        const childNode2 = new SomeNode("Child2");
+
+        const parentNode = new SomeNodeInPackage("ParentNode");
+
+        parentNode.setChild('someNode', childNode1);
+        expect(parentNode.getChildren('someNode')).to.eql([childNode1]);
+        childNode1.replaceWith(childNode2);
+        expect(parentNode.getChildren('someNode')).to.eql([childNode2]);
+    });
+
+    it('should throw error if parent is not set', () => {
+        const childNode1 = new SomeNode("Child1");
+
+        const nodeWithoutParent = new SomeNode("NodeWithoutParent");
+        expect(() => nodeWithoutParent.replaceWith(childNode1)).to.throw('Cannot replace a Node that has no parent');
+    });
+});
+


### PR DESCRIPTION
Resolve #49
Inspired by [Kolasu's `NodeLike.transformChildren`](https://github.com/Strumenta/kolasu/blob/0676131e403718d2d99c792dc0a81a87bd48a34f/core/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt#L328) and [Kolasu's `NodeLike.replaceWith`](https://github.com/Strumenta/kolasu/blob/0676131e403718d2d99c792dc0a81a87bd48a34f/core/src/main/kotlin/com/strumenta/kolasu/model/Processing.kt#L417)

---
The above message has been included in the commit's description.
Test coverage has been extended to the new features.
The changelog has been updated to reflect the changes, with the version Unreleased to facilitate library moderation.