### PR TITLE
`assertASTsAreEqual`: don't depend on Chai

### DIFF
--- a/src/testing/testing.ts
+++ b/src/testing/testing.ts
@@ -1,6 +1,5 @@
 import {Node} from "../model/model";
-import {fail} from "assert";
-import {expect} from "chai";
+import {strictEqual,deepStrictEqual,fail} from "node:assert";
 
 export function assertASTsAreEqual(
     expected: Node,
@@ -10,7 +9,7 @@ export function assertASTsAreEqual(
 ): void {
     if (areSameType(expected, actual)) {
         if (considerPosition) {
-            expect(actual.position, `${context}.position`).to.eql(expected.position);
+            deepStrictEqual(actual.position, expected.position, `${context}.position`);
         }
         expected.features.forEach(expectedProperty => {
             const actualPropValue = actual.features.find(p => p.name == expectedProperty.name)!.value;
@@ -25,10 +24,11 @@ export function assertASTsAreEqual(
                 );
             }
             else if (Array.isArray(actualPropValue) && Array.isArray(expectedPropValue)) {
-                expect(
+                strictEqual(
                     actualPropValue.length,
+                    expectedPropValue.length,
                     `${context}, property ${expectedProperty.name} has length ${expectedPropValue.length}, but found ${actualPropValue.length}`
-                ).to.equal(expectedPropValue.length)
+                );
                 for (let i = 0; i < expectedPropValue.length; i++) {
                     const expectedElement = expectedPropValue[i];
                     const actualElement = actualPropValue[i];
@@ -42,18 +42,20 @@ export function assertASTsAreEqual(
                         );
                     }
                     else if (typeof expectedElement != "object" && typeof actualElement != "object") {
-                        expect(
+                        strictEqual(
                             actualElement,
-                            `${context}, property ${expectedProperty.name}[${i}] is ${expectedPropValue[i]}, but found ${actualPropValue[i]}`
-                        ).to.equal(expectedElement);
+                            expectedElement,
+                            `${context}, property ${expectedProperty.name}[${i}] is ${expectedPropValue[i]}, but found ${actualPropValue[i]}`,
+                        );
                     }
                 }
             }
             else {
-                expect(
+                strictEqual(
                     actualPropValue,
-                    `${context}, comparing property ${expectedProperty.name}`
-                ).to.equal(expectedPropValue);
+                    expectedPropValue,
+                    `${context}, property ${expectedProperty.name} is '${expectedPropValue}', but found '${actualPropValue}'`
+                );
             }
         });
     }

--- a/tests/testing/testing.test.ts
+++ b/tests/testing/testing.test.ts
@@ -40,7 +40,7 @@ describe('AssertASTsAreEqual', function() {
         const simpleNode2 : Node = new SimpleNode("different node");
         expect(() =>
             assertASTsAreEqual(simpleNode1, simpleNode2)
-        ).to.throw("expected 'different node' to equal 'node'");
+        ).to.throw("<root>, property name is 'node', but found 'different node'");
     });
     it("two different node instances of two different types, but with same values must NOT pass", function () {
         const node1 : Node = new SimpleNode("node");


### PR DESCRIPTION
Addresses the need not to depend on chai in `assertASTsAreEqual`, as per #35.

While pondering the changes I've made I gave a look at the coverage for `assertASTsAreEqual` and found out that there are two branches not covered, while being [not particularly fond of 100% coverage per se](https://testing.googleblog.com/2020/08/code-coverage-best-practices.html) I still think it gives some useful insights. 

First unconvered branch is the right side of [this expression](https://github.com/Strumenta/tylasu/blob/master/src/testing/testing.ts#L19), I could not find a suitable test input that could lead there, my hunch is that it's related to [this `any`](https://github.com/Strumenta/tylasu/blob/master/src/model/model.ts#L363): I believe that if we could express all types involved then the type checker could do the heavy lifting for us looking for pattern matching exhaustiveness.

Second one is [this ](https://github.com/Strumenta/tylasu/blob/master/src/testing/testing.ts#L44), and it too, I believe, is related to the above `any`.

I've looked around and I've seen that `value`  of type `FeatureDescription` is being used as 
 * [`ReferenceByName`](https://github.com/Strumenta/tylasu/blob/master/src/interop/indexing.ts#L44)
 * `Node[]` or as a `Node`, in the two above branches
 * [`Node[]` or `Node`](https://github.com/Strumenta/tylasu/blob/master/src/traversing/structurally.ts#L97)

At this point I would ask a colleague for guidance, showing my findings, to discuss if and how to progress this.

---

General notes

* chaijs' expect when expecting exception checks if the expected message is part of the message in the exception, this might be confusing sometimes, my take would be to use the whole exception message
* in my experience Jest considers `it.only` and `describe.only` only if focusing on the file they're used (because tests run in parallel); if you're interested I could submit a PR that allows to filter tests, unless I'm missing something crucial in the development process