### PR TITLE
Aligning Token Categories with Kolasu

### DIFF
--- a/src/parsing/parsing.ts
+++ b/src/parsing/parsing.ts
@@ -10,7 +10,12 @@ export enum TokenCategory {
     KEYWORD = "Keyword",
     NUMERIC_LITERAL = "Numeric literal",
     STRING_LITERAL = "String literal",
-    PLAIN_TEXT = "Plain text"
+    OTHER_LITERAL = "Other literal",
+    PLAIN_TEXT = "Plain text",
+    WHITESPACE = "Whitespace",
+    IDENTIFIER = "Identifier",
+    PUNCTUATION = "Punctuation",
+    OPERATOR = "Operator",
 }
 
 /**


### PR DESCRIPTION
With this PR we align the Token Categories to the ones we have in Kolasu:

https://github.com/Strumenta/kolasu/blob/2053bffbc615a35f06a3d49f59984a5e6a6568dd/ast/src/commonMain/kotlin/com/strumenta/kolasu/parsing/TokenCategory.kt#L3-L23

I considered https://github.com/Strumenta/kolasu/issues/381 but that list seems to be working for modern languages and not be so adapted to legacy languages, like the ones that we routinely work with